### PR TITLE
sshd_config: remove deprecated UsePrivilegeSeparation

### DIFF
--- a/templates/sshd_config
+++ b/templates/sshd_config
@@ -13,7 +13,6 @@ Ciphers {{ sshd_Ciphers | join(",") }}
 KexAlgorithms {{ sshd_KexAlgorithms | join(",") }}
 MACs {{ sshd_MACs | join(",") }}
 
-UsePrivilegeSeparation sandbox
 Subsystem sftp /usr/libexec/sftp-server
 PermitRootLogin no
 


### PR DESCRIPTION
This spams syslog with
```
sshd[24734]: rexec line 12: Deprecated option UsePrivilegeSeparation
```

https://www.openssh.com/txt/release-7.5
```
 * This release deprecates the sshd_config UsePrivilegeSeparation
   option, thereby making privilege separation mandatory. Privilege
   separation has been on by default for almost 15 years and
   sandboxing has been on by default for almost the last five.
```