### PR TITLE
Remove hmac-ripemd160 as a default option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,6 @@ sshd_KexAlgorithms:
 sshd_MACs:
   - hmac-sha2-512-etm@openssh.com
   - hmac-sha2-512,hmac-sha2-256
-  - hmac-ripemd160
 
 sshd_AuthenticationMethods:
   - publickey


### PR DESCRIPTION
OpenSSH 7.6/7.6p1 official removes support for hmac-ripemd160.
OpenSSH currently fails if hmac-ripemd160 is specified as an
option.